### PR TITLE
increase gasLimit to be over gas estimate

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -383,7 +383,7 @@ export default defineComponent({
 
         let payMethod = collateralContract.methods.deposit(metaAddress.value)
         let payGasLimit = await payMethod.estimateGas({ from: metaAddress.value })
-        const tx = await payMethod.send({ from: metaAddress.value, gasLimit: payGasLimit, value: amount })
+        const tx = await payMethod.send({ from: metaAddress.value, gasLimit: Math.floor(payGasLimit * 1.5), value: amount })
           .on('transactionHash', async (transactionHash) => {
             console.log('transactionHash:', transactionHash)
             cpCollateralCont.tx_hash = transactionHash


### PR DESCRIPTION
Was getting error
```
Transaction has been reverted by the EVM: { ...
```

Ensure that the gas limit provided when sending the transaction is sufficient. If the gas limit is too low, it might cause the transaction to run out of gas and be reverted.